### PR TITLE
fix: do not initialize firebase twice (GEN-30)

### DIFF
--- a/src/pages/settings/organization/index.tsx
+++ b/src/pages/settings/organization/index.tsx
@@ -1,19 +1,18 @@
-import { GetServerSidePropsContext } from 'next';
-import { Trans } from 'next-i18next';
-import Head from 'next/head';
+import { GetServerSidePropsContext } from "next";
+import { Trans } from "next-i18next";
+import Head from "next/head";
 
-import { withAppProps } from '~/lib/props/with-app-props';
+import { withAppProps } from "~/lib/props/with-app-props";
 
-import FirebaseStorageProvider from '~/core/firebase/components/FirebaseStorageProvider';
-import UpdateOrganizationForm from '~/components/organizations/UpdateOrganizationForm';
-import OrganizationSettingsTabs from '~/components/organizations/OrganizationSettingsTabs';
-import SettingsPageContainer from '~/components/settings/SettingsPageContainer';
-import SettingsContentContainer from '~/components/settings/SettingsContentContainer';
-import SettingsTile from '~/components/settings/SettingsTile';
+import UpdateOrganizationForm from "~/components/organizations/UpdateOrganizationForm";
+import OrganizationSettingsTabs from "~/components/organizations/OrganizationSettingsTabs";
+import SettingsPageContainer from "~/components/settings/SettingsPageContainer";
+import SettingsContentContainer from "~/components/settings/SettingsContentContainer";
+import SettingsTile from "~/components/settings/SettingsTile";
 
 const Organization = () => {
   return (
-    <SettingsPageContainer title={'Settings'}>
+    <SettingsPageContainer title={"Settings"}>
       <Head>
         <title key="title">Organization Settings</title>
       </Head>
@@ -22,14 +21,10 @@ const Organization = () => {
 
       <SettingsContentContainer>
         <SettingsTile
-          heading={<Trans i18nKey={'organization:generalTabLabel'} />}
-          subHeading={
-            <Trans i18nKey={'organization:generalTabLabelSubheading'} />
-          }
+          heading={<Trans i18nKey={"organization:generalTabLabel"} />}
+          subHeading={<Trans i18nKey={"organization:generalTabLabelSubheading"} />}
         >
-          <FirebaseStorageProvider>
-            <UpdateOrganizationForm />
-          </FirebaseStorageProvider>
+          <UpdateOrganizationForm />
         </SettingsTile>
       </SettingsContentContainer>
     </SettingsPageContainer>

--- a/src/pages/settings/profile/index.tsx
+++ b/src/pages/settings/profile/index.tsx
@@ -1,24 +1,23 @@
-import { useCallback, useContext } from 'react';
-import { GetServerSidePropsContext } from 'next';
-import { Trans } from 'next-i18next';
-import { UserInfo } from 'firebase/auth';
-import { useUser } from 'reactfire';
+import { useCallback, useContext } from "react";
+import { GetServerSidePropsContext } from "next";
+import { Trans } from "next-i18next";
+import { UserInfo } from "firebase/auth";
+import { useUser } from "reactfire";
 
-import FirebaseStorageProvider from '~/core/firebase/components/FirebaseStorageProvider';
+import { withAppProps } from "~/lib/props/with-app-props";
+import { UserSessionContext } from "~/core/contexts/user-session";
 
-import { withAppProps } from '~/lib/props/with-app-props';
-import { UserSessionContext } from '~/core/contexts/user-session';
-
-import UpdateProfileForm from '~/components/profile/UpdateProfileForm';
-import ProfileSettingsTabs from '~/components/profile/ProfileSettingsTabs';
-import SettingsPageContainer from '~/components/settings/SettingsPageContainer';
-import SettingsContentContainer from '~/components/settings/SettingsContentContainer';
-import SettingsTile from '~/components/settings/SettingsTile';
-import Head from 'next/head';
+import UpdateProfileForm from "~/components/profile/UpdateProfileForm";
+import ProfileSettingsTabs from "~/components/profile/ProfileSettingsTabs";
+import SettingsPageContainer from "~/components/settings/SettingsPageContainer";
+import SettingsContentContainer from "~/components/settings/SettingsContentContainer";
+import SettingsTile from "~/components/settings/SettingsTile";
+import Head from "next/head";
 
 type ProfileData = Partial<UserInfo>;
 
 const Profile = () => {
+  console.log("Profile провалились");
   const { userSession, setUserSession } = useContext(UserSessionContext);
   const { data: user } = useUser();
 
@@ -36,7 +35,7 @@ const Profile = () => {
         });
       }
     },
-    [setUserSession, userSession]
+    [setUserSession, userSession],
   );
 
   if (!user) {
@@ -44,21 +43,19 @@ const Profile = () => {
   }
 
   return (
-    <SettingsPageContainer title={'Settings'}>
+    <SettingsPageContainer title={"Settings"}>
       <Head>
-        <title key={'title'}>My Details</title>
+        <title key={"title"}>My Details</title>
       </Head>
 
       <ProfileSettingsTabs />
 
       <SettingsContentContainer>
         <SettingsTile
-          heading={<Trans i18nKey={'profile:generalTab'} />}
-          subHeading={<Trans i18nKey={'profile:generalTabSubheading'} />}
+          heading={<Trans i18nKey={"profile:generalTab"} />}
+          subHeading={<Trans i18nKey={"profile:generalTabSubheading"} />}
         >
-          <FirebaseStorageProvider>
-            <UpdateProfileForm user={user} onUpdate={onUpdate} />
-          </FirebaseStorageProvider>
+          <UpdateProfileForm user={user} onUpdate={onUpdate} />
         </SettingsTile>
       </SettingsContentContainer>
     </SettingsPageContainer>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

**Refactor:**
- Updated the organization and structure of code in the Settings pages for improved maintainability.
- Removed unused `FirebaseStorageProvider` component from both Profile and Organization settings pages.

**Style:**
- Enhanced the user interface of the Settings pages by refining the presentation of titles and headings.
- Minor updates to the `SettingsPageContainer` and `SettingsTile` components for better readability and consistency.

These changes primarily focus on improving the code's organization and the user interface's clarity, contributing to a more intuitive and user-friendly experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->