### PR TITLE
Max media file duration

### DIFF
--- a/src/core/flagsmith/features-ids-list.ts
+++ b/src/core/flagsmith/features-ids-list.ts
@@ -1,5 +1,6 @@
 const FEATURES_IDS_LIST = {
-	languages_list: "languages_list",
+  languages_list: "languages_list",
+  max_media_file_duration_in_minutes: "max_media_file_duration_in_minutes",
 };
 
 export default FEATURES_IDS_LIST;

--- a/src/lib/projects/hooks/use-max-media-file-duration.ts
+++ b/src/lib/projects/hooks/use-max-media-file-duration.ts
@@ -1,0 +1,18 @@
+import flagsmith from "flagsmith";
+import FEATURES_IDS_LIST from "~/core/flagsmith/features-ids-list";
+
+const useMaxMediaFileDuration = () => {
+  const valueString: string = flagsmith.getValue(
+    FEATURES_IDS_LIST.max_media_file_duration_in_minutes,
+  );
+  const maxMediaFileDurationInMinutes = Number(valueString);
+
+  const MAX_MEDIA_FILE_DURATION = {
+    inMinutes: maxMediaFileDurationInMinutes,
+    inSeconds: maxMediaFileDurationInMinutes * 60,
+  };
+
+  return MAX_MEDIA_FILE_DURATION;
+};
+
+export default useMaxMediaFileDuration;


### PR DESCRIPTION
## Выполнено
- Сделал хук для получения с **Flagsmith** максимальной длительности видоса или аудио для загрузки
- Если аудио или видео длится дольше, чем указанное время, то выдаётся ошибка "файл слишком долгий, загрузи покороче"

### Вот как выглядит ошибка
![image](https://github.com/AudioLand/dub-nextjs/assets/46379146/1b8f00e3-ccda-455c-a327-9610e5039b45)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: Introduced a maximum duration limit for media files. This enhancement ensures that only media files within a certain duration can be uploaded, improving the overall user experience and system performance.
- Refactor: Streamlined the file upload process by separating the logic for handling dropped and uploaded files. This change enhances the system's reliability and maintainability.
- Style: Improved code readability by fixing the indentation of the `languages_list` property. This change doesn't affect the functionality but makes the code easier to understand for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->