### PR TITLE
Remove project btn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "cva": "npm:class-variance-authority@^0.7.0",
         "date-fns": "2.30.0",
         "feed": "^4.2.2",
+        "file-saver": "^2.0.5",
         "firebase": "^9.23.0",
         "firebase-admin": "^11.11.0",
         "firebase-functions": "^4.3.1",
@@ -58,6 +59,7 @@
       "devDependencies": {
         "@cypress/webpack-preprocessor": "^6.0.0",
         "@next/bundle-analyzer": "13.5.4",
+        "@types/file-saver": "^2.0.6",
         "@types/jest": "^29.5.5",
         "@types/node": "^20.8.4",
         "@types/nodemailer": "^6.4.11",
@@ -5973,6 +5975,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/file-saver": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.6.tgz",
+      "integrity": "sha512-Mw671DVqoMHbjw0w4v2iiOro01dlT/WhWp5uwecBa0Wg8c+bcZOjgF1ndBnlaxhtvFCgTRBtsGivSVhrK/vnag==",
+      "dev": true
     },
     "node_modules/@types/glob": {
       "version": "8.1.0",
@@ -12016,6 +12024,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/filesize": {
       "version": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "cva": "npm:class-variance-authority@^0.7.0",
     "date-fns": "2.30.0",
     "feed": "^4.2.2",
+    "file-saver": "^2.0.5",
     "firebase": "^9.23.0",
     "firebase-admin": "^11.11.0",
     "firebase-functions": "^4.3.1",
@@ -91,6 +92,7 @@
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^6.0.0",
     "@next/bundle-analyzer": "13.5.4",
+    "@types/file-saver": "^2.0.6",
     "@types/jest": "^29.5.5",
     "@types/node": "^20.8.4",
     "@types/nodemailer": "^6.4.11",

--- a/src/components/projects/ProjectsTable.tsx
+++ b/src/components/projects/ProjectsTable.tsx
@@ -1,21 +1,14 @@
 // react
+import { saveAs } from "file-saver";
 import { FC } from "react";
 import Badge from "~/core/ui/Badge";
 
 // ui-components
 import Button from "~/core/ui/Button";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "~/core/ui/Table";
-
-import PROJECT_STATUSES from "~/lib/projects/statuses";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/core/ui/Table";
 
 // types
+import PROJECT_STATUSES from "~/lib/projects/statuses";
 import { Project } from "~/lib/projects/types/project";
 
 interface ProjectsTableProps {
@@ -41,6 +34,15 @@ export const ProjectsTable: FC<ProjectsTableProps> = (props) => {
     }
   };
 
+  const isButtonDisabled = (projectStatus: PROJECT_STATUSES) => {
+    return projectStatus !== PROJECT_STATUSES.translated;
+  };
+
+  const handleDownloadTranslatedFile = (translatedFileLink: string) => {
+    const filename = translatedFileLink.split("/").pop();
+    saveAs(translatedFileLink, filename);
+  };
+
   return (
     <Table>
       <TableHeader>
@@ -54,7 +56,7 @@ export const ProjectsTable: FC<ProjectsTableProps> = (props) => {
       </TableHeader>
 
       <TableBody>
-        {projects?.map(({ id, name, targetLanguage, status, createdAt }) => (
+        {projects?.map(({ id, name, targetLanguage, translatedFileLink, status, createdAt }) => (
           <TableRow key={id}>
             {/* Project Fields Values */}
             <TableCell>{name}</TableCell>
@@ -69,12 +71,13 @@ export const ProjectsTable: FC<ProjectsTableProps> = (props) => {
 
             {/* Project Buttons */}
             <TableCell className="flex flex-row gap-5">
-              <Button variant="destructive">Remove</Button>
-              <Button>Download</Button>
               <Button
-                disabled={status !== PROJECT_STATUSES.translated}
-                href={`/projects/${id}`}
+                disabled={isButtonDisabled(status)}
+                onClick={() => handleDownloadTranslatedFile(translatedFileLink)}
               >
+                Download
+              </Button>
+              <Button disabled={isButtonDisabled(status)} href={`/projects/${id}`}>
                 View
               </Button>
             </TableCell>


### PR DESCRIPTION
## Выполнено
- Убрал кнопку удаления проекта
- Сделал, чтобы пока проект переводится, кнопка скачать была не доступна
- Сделал, чтобы переведённый проект можно было скачать

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: Added a "Download" button for translated files in the project table. This button allows users to easily download their translated files directly from the project overview.
- Improvement: Implemented a new feature that disables the "Download" button for projects that are not yet completed. This ensures users can only download files when they are ready and fully translated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->