### PR TITLE
fix: set Yearly plan as default for select

### DIFF
--- a/src/components/PricingTable.tsx
+++ b/src/components/PricingTable.tsx
@@ -50,7 +50,8 @@ function PricingTable(
     CheckoutButton?: React.ComponentType<CheckoutButtonProps>;
   }>,
 ) {
-  const [planVariant, setPlanVariant] = useState<string>(STRIPE_PLANS[0]);
+  //* Default plan - Yearly
+  const [planVariant, setPlanVariant] = useState<string>(STRIPE_PLANS[1]);
 
   return (
     <div className={"flex flex-col space-y-12"}>
@@ -210,13 +211,14 @@ function PlansSwitcher(
   }>,
 ) {
   return (
-    <div className={"flex"}>
+    //* Reversed to set Yearly plan the first
+    <div className={"flex flex-row-reverse"}>
       {props.plans.map((plan, index) => {
         const selected = plan === props.plan;
 
         const className = classNames("focus:!ring-0 !outline-none", {
-          "rounded-r-none": index === 0,
-          "rounded-l-none": index === props.plans.length - 1,
+          "rounded-l-none": index === 0,
+          "rounded-r-none": index === props.plans.length - 1,
           ["border-gray-100 dark:border-dark-800 hover:bg-gray-50" +
           " dark:hover:bg-background/80"]: !selected,
         });


### PR DESCRIPTION
## Выполнено
- Сделал, чтобы подефолту был годовой план и чтобы он стоял первый в свитчере планов

### Вот так теперь это выглядит
![image](https://github.com/AudioLand/dub-nextjs/assets/46379146/66324db3-4d16-4472-9dba-f0caf984501f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Style:
- Updated the `PricingTable` component to now display the second item in `STRIPE_PLANS` as the default plan, providing a different initial view for users.
- Adjusted the CSS class order for rounded corners in the `PlansSwitcher` component, subtly altering the visual presentation. No changes to functionality or logic were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->