### PR TITLE
fix: remove subscription item id arg in request

### DIFF
--- a/src/components/projects/CreateProjectForm.tsx
+++ b/src/components/projects/CreateProjectForm.tsx
@@ -10,7 +10,6 @@ import FileUploader from "./FileUploader";
 
 // hooks
 import { useUserId } from "~/core/hooks/use-user-id";
-import useCurrentOrganizationSubscriptionItemId from "~/lib/organizations/hooks/use-current-organization-subscription-item-id";
 import useCreateProject from "~/lib/projects/hooks/use-create-project";
 import useTargetLanguages from "~/lib/projects/hooks/use-target-languages";
 import useUpdateProject from "~/lib/projects/hooks/use-update-project";
@@ -32,7 +31,6 @@ const CreateProjectForm: FC<CreateProjectFormProps> = (props) => {
   const { handleClose } = props;
 
   const userId = useUserId()!;
-  const subscriptionItemId = useCurrentOrganizationSubscriptionItemId();
   const targetLanguages = useTargetLanguages();
   const createNewProject = useCreateProject();
   const uploadFileToStorage = useUploadFileToStorage();
@@ -142,10 +140,6 @@ const CreateProjectForm: FC<CreateProjectFormProps> = (props) => {
         target_language: createdProject.targetLanguage,
         original_file_location: filePathInBucket,
       });
-
-      if (subscriptionItemId) {
-        requestParams.append("subscription_item_id", subscriptionItemId);
-      }
 
       const url = `${PIPELINE_URL}/?${requestParams.toString()}`;
       const response = await fetch(url);


### PR DESCRIPTION
## Выполнено
- Убрал отправку `subscription_item_id` в запросе к пайплайну

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Refactor:
- Removed the usage of `subscriptionItemId` in the project creation process. This change simplifies the project creation form and may affect how projects are associated with specific subscriptions. Please note that this might alter the way projects are created and managed within the organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->