### PR TITLE
Set email events sending

### DIFF
--- a/src/core/email/send-email.ts
+++ b/src/core/email/send-email.ts
@@ -1,9 +1,10 @@
-import { Address } from "nodemailer/lib/mailer";
+import Mail, { Address } from "nodemailer/lib/mailer";
 import configuration from "../../configuration";
 
 interface SendEmailParams {
   to: string;
   subject: string;
+  priority?: Mail.Options["priority"];
   text?: string;
   html?: string;
 }

--- a/src/core/flagsmith/features-ids-list.ts
+++ b/src/core/flagsmith/features-ids-list.ts
@@ -1,6 +1,17 @@
 const FEATURES_IDS_LIST = {
   languages_list: "languages_list",
   requirements_info_tooltip: "requirements_info_tooltip",
+
+  emailTexts: {
+    notification_of_a_failed_payment_attempt: "notification_of_a_failed_payment_attempt",
+    notification_of_successful_registration: "notification_of_successful_registration",
+    password_successfully_reset: "password_successfully_reset",
+    project_translation_error: "project_translation_error",
+    successful_purchase_of_tokens: "successful_purchase_of_tokens",
+    successful_subscription: "successful_subscription",
+    successful_translation_of_the_project: "successful_translation_of_the_project",
+    warning_about_the_end_of_the_subscription: "warning_about_the_end_of_the_subscription",
+  },
 };
 
 export default FEATURES_IDS_LIST;

--- a/src/core/flagsmith/features-ids-list.ts
+++ b/src/core/flagsmith/features-ids-list.ts
@@ -11,6 +11,7 @@ const FEATURES_IDS_LIST = {
     successful_subscription: "successful_subscription",
     successful_translation_of_the_project: "successful_translation_of_the_project",
     warning_about_the_end_of_the_subscription: "warning_about_the_end_of_the_subscription",
+    successful_subscription_renewal: "successful_subscription_renewal",
   },
 };
 

--- a/src/core/stripe/stripe-webhooks.enum.ts
+++ b/src/core/stripe/stripe-webhooks.enum.ts
@@ -9,4 +9,5 @@ export enum StripeWebhooks {
   SubscriptionDeleted = "customer.subscription.deleted",
   SubscriptionUpdated = "customer.subscription.updated",
   InvoicePaid = "invoice.paid",
+  InvoicePaymentFailed = "invoice.payment_failed",
 }

--- a/src/lib/emails/get-event-emails-texts.ts
+++ b/src/lib/emails/get-event-emails-texts.ts
@@ -1,0 +1,11 @@
+import flagsmith from "flagsmith";
+import { EventEmail } from "./types/event-email";
+
+const getEventEmailText = (flagsmithTag: string) => {
+  const valueString: string = flagsmith.getValue(flagsmithTag);
+  const eventEmail: EventEmail = JSON.parse(valueString);
+
+  return eventEmail;
+};
+
+export default getEventEmailText;

--- a/src/lib/emails/types/event-email.ts
+++ b/src/lib/emails/types/event-email.ts
@@ -1,0 +1,4 @@
+export type EventEmail = {
+  subject: string;
+  text: string;
+};

--- a/src/pages/api/onboarding/index.ts
+++ b/src/pages/api/onboarding/index.ts
@@ -1,22 +1,30 @@
-import { NextApiRequest, NextApiResponse } from 'next';
-import { z } from 'zod';
+import { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { sendEmail } from "~/core/email/send-email";
+import FEATURES_IDS_LIST from "~/core/flagsmith/features-ids-list";
 
-import { completeOnboarding } from '~/lib/server/onboarding/complete-onboarding';
-import { withPipe } from '~/core/middleware/with-pipe';
-import { withAuthedUser } from '~/core/middleware/with-authed-user';
-import { withMethodsGuard } from '~/core/middleware/with-methods-guard';
-import { withExceptionFilter } from '~/core/middleware/with-exception-filter';
-import withCsrf from '~/core/middleware/with-csrf';
+import { withAuthedUser } from "~/core/middleware/with-authed-user";
+import withCsrf from "~/core/middleware/with-csrf";
+import { withExceptionFilter } from "~/core/middleware/with-exception-filter";
+import { withMethodsGuard } from "~/core/middleware/with-methods-guard";
+import { withPipe } from "~/core/middleware/with-pipe";
+import getEventEmailText from "~/lib/emails/get-event-emails-texts";
+import { completeOnboarding } from "~/lib/server/onboarding/complete-onboarding";
 
 const Body = z.object({
   organization: z.string(),
 });
 
-const SUPPORTED_HTTP_METHODS: HttpMethod[] = ['POST'];
+const SUPPORTED_HTTP_METHODS: HttpMethod[] = ["POST"];
 
 async function onboardingHandler(req: NextApiRequest, res: NextApiResponse) {
   const body = await Body.parseAsync(req.body);
   const userId = req.firebaseUser.uid;
+  const userEmail = req.firebaseUser.email;
+
+  if (!userEmail) {
+    return res.send({ success: false });
+  }
 
   const data = {
     userId,
@@ -25,18 +33,29 @@ async function onboardingHandler(req: NextApiRequest, res: NextApiResponse) {
 
   await completeOnboarding(data);
 
+  if (userEmail) {
+    const registrationEmail = getEventEmailText(
+      FEATURES_IDS_LIST.emailTexts.notification_of_successful_registration,
+    );
+
+    sendEmail({
+      to: userEmail,
+      subject: registrationEmail.subject,
+      text: registrationEmail.text,
+    });
+  } else {
+    console.error("User email is not defined in registration request");
+  }
+
   return res.send({ success: true });
 }
 
-export default function completeOnboardingHandler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
+export default function completeOnboardingHandler(req: NextApiRequest, res: NextApiResponse) {
   const handler = withPipe(
     withCsrf(),
     withMethodsGuard(SUPPORTED_HTTP_METHODS),
     withAuthedUser,
-    onboardingHandler
+    onboardingHandler,
   );
 
   return withExceptionFilter(req, res)(handler);

--- a/src/pages/api/onboarding/index.ts
+++ b/src/pages/api/onboarding/index.ts
@@ -22,10 +22,6 @@ async function onboardingHandler(req: NextApiRequest, res: NextApiResponse) {
   const userId = req.firebaseUser.uid;
   const userEmail = req.firebaseUser.email;
 
-  if (!userEmail) {
-    return res.send({ success: false });
-  }
-
   const data = {
     userId,
     organizationName: body.organization,

--- a/src/pages/api/stripe/webhook.ts
+++ b/src/pages/api/stripe/webhook.ts
@@ -122,7 +122,7 @@ async function checkoutWebhooksHandler(req: NextApiRequest, res: NextApiResponse
 
         if (userEmail) {
           const subscriptionRenewalEmail = getEventEmailText(
-            FEATURES_IDS_LIST.emailTexts.notification_of_successful_registration,
+            FEATURES_IDS_LIST.emailTexts.successful_subscription_renewal,
           );
 
           sendEmail({
@@ -143,7 +143,7 @@ async function checkoutWebhooksHandler(req: NextApiRequest, res: NextApiResponse
 
         if (userEmail) {
           const paymentFailedEmail = getEventEmailText(
-            FEATURES_IDS_LIST.emailTexts.notification_of_successful_registration,
+            FEATURES_IDS_LIST.emailTexts.notification_of_a_failed_payment_attempt,
           );
 
           sendEmail({

--- a/src/pages/api/stripe/webhook.ts
+++ b/src/pages/api/stripe/webhook.ts
@@ -121,6 +121,27 @@ async function checkoutWebhooksHandler(req: NextApiRequest, res: NextApiResponse
 
         break;
       }
+
+      case StripeWebhooks.InvoicePaymentFailed: {
+        const invoice = event.data.object as Stripe.Invoice;
+        const userEmail = invoice.customer_email;
+
+        if (userEmail) {
+          const paymentFailedEmail = getEventEmailText(
+            FEATURES_IDS_LIST.emailTexts.notification_of_successful_registration,
+          );
+
+          sendEmail({
+            to: userEmail,
+            subject: paymentFailedEmail.subject,
+            text: paymentFailedEmail.text,
+          });
+        } else {
+          console.error("User email is not defined in Stripe failed invoice event");
+        }
+
+        break;
+      }
     }
 
     return respondOk(res);

--- a/src/pages/api/stripe/webhook.ts
+++ b/src/pages/api/stripe/webhook.ts
@@ -116,8 +116,23 @@ async function checkoutWebhooksHandler(req: NextApiRequest, res: NextApiResponse
 
       case StripeWebhooks.InvoicePaid: {
         const invoice = event.data.object as Stripe.Invoice;
+        const userEmail = invoice.customer_email;
 
         await onSubscriptionContinued(invoice);
+
+        if (userEmail) {
+          const subscriptionRenewalEmail = getEventEmailText(
+            FEATURES_IDS_LIST.emailTexts.notification_of_successful_registration,
+          );
+
+          sendEmail({
+            to: userEmail,
+            subject: subscriptionRenewalEmail.subject,
+            text: subscriptionRenewalEmail.text,
+          });
+        } else {
+          console.error("User email is not defined in Stripe paid invoice event");
+        }
 
         break;
       }


### PR DESCRIPTION
## Выполнено
- Добавил получение текстовок писем с **Flagsmith**
- Добавил `priority` в пропсы функции `sendEmail`
- Добавил отправку письма юзеру на почту на ивенты:
  - [x]  Уведомление об успешной регистрации, welcome email
  - [x]  Успешная подписка с указанием тарифа
  - [x]  Уведомление о неудачной попытке снятия денег, призыв оплатить вручную
  - [x]  Успешное продление подписки (автоподписки как годовой так и месячной)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced priority setting for emails.
	- Added email notifications for various events.
- **Refactor**
	- Enhanced email sending functionality with additional parameters.
- **Chores**
	- Updated import statements and middleware usage.
- **Bug Fixes**
	- Improved handling of user email in the onboarding process.
- **Tests**
	- Added conditional blocks for email sending based on Stripe events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->