### PR TITLE
Set emails events

### DIFF
--- a/src/core/stripe/stripe-webhooks.enum.ts
+++ b/src/core/stripe/stripe-webhooks.enum.ts
@@ -10,4 +10,5 @@ export enum StripeWebhooks {
   SubscriptionUpdated = "customer.subscription.updated",
   InvoicePaid = "invoice.paid",
   InvoicePaymentFailed = "invoice.payment_failed",
+  InvoiceUpcoming = "invoice.upcoming",
 }

--- a/src/lib/emails/templates/subscription-auto-renew.tsx
+++ b/src/lib/emails/templates/subscription-auto-renew.tsx
@@ -2,9 +2,7 @@ import { Text } from "@react-email/components";
 import { OrganizationSubscription } from "~/lib/organizations/types/organization-subscription";
 import { renderEmailHtml } from "./render-email-html";
 
-export const getSuccessfulSubscriptionAutoRenewEmailTemplate = (
-  subscription: OrganizationSubscription,
-) => {
+export const getSubscriptionAutoRenewEmailTemplate = (subscription: OrganizationSubscription) => {
   const periodEndAsDate = new Date(subscription.periodEndsAt * 1000);
   const nextBillingDate = periodEndAsDate.toDateString();
 

--- a/src/lib/emails/templates/subscription-expiration.tsx
+++ b/src/lib/emails/templates/subscription-expiration.tsx
@@ -1,0 +1,31 @@
+import { Text } from "@react-email/components";
+import { renderEmailHtml } from "./render-email-html";
+
+export const getSubscriptionExpirationEmailTemplate = () => {
+  const subject = "Heads Up! Your Audioland Subscription Expires in 3 Days ⏳";
+
+  const html = renderEmailHtml(
+    <>
+      <Text>Hey!</Text>
+      <br />
+
+      <Text>
+        It&apos;s Dima from Audioland. Just a quick reminder that your subscription is set to expire
+        in 3 days. Don&apos;t miss out on uninterrupted service!
+      </Text>
+      <br />
+
+      <Text>
+        Want to keep the translations flowing? Simply renew your plan, and let&apos;s keep breaking
+        those language barriers.
+      </Text>
+      <br />
+
+      <Text>Here for you,</Text>
+      <Text>Dima A</Text>
+      <Text>CEO & Co-founder, Audioland</Text>
+    </>,
+  );
+
+  return { subject, html };
+};

--- a/src/lib/emails/templates/successful-subscription.tsx
+++ b/src/lib/emails/templates/successful-subscription.tsx
@@ -5,7 +5,7 @@ import { renderEmailHtml } from "./render-email-html";
 
 const STRIPE_PRODUCTS = configuration.stripe.products;
 
-export const getSuccessfulSubscriptionWithPlanDetailsEmailTemplate = (
+export const getSuccessfulSubscriptionEmailTemplate = (
   subscription: OrganizationSubscription,
 ) => {
   const userSubscriptionPlan = STRIPE_PRODUCTS.find(

--- a/src/pages/api/emails/send.ts
+++ b/src/pages/api/emails/send.ts
@@ -19,7 +19,6 @@ const SUPPORTED_HTTP_METHODS: HttpMethod[] = ["POST"];
 async function sendEmailHandler(req: NextApiRequest, res: NextApiResponse) {
   const { userEmail, htmlTemplate } = await Body.parseAsync(req.body);
 
-  // const eventEmailTexts = await fetchEventEmailText(textsFlagId);
   await sendEmail({
     to: userEmail,
     subject: htmlTemplate.subject,

--- a/src/pages/api/onboarding/index.ts
+++ b/src/pages/api/onboarding/index.ts
@@ -6,6 +6,8 @@ import withCsrf from "~/core/middleware/with-csrf";
 import { withExceptionFilter } from "~/core/middleware/with-exception-filter";
 import { withMethodsGuard } from "~/core/middleware/with-methods-guard";
 import { withPipe } from "~/core/middleware/with-pipe";
+import sendEmailWithApi from "~/lib/emails/hooks/send-email-with-api";
+import { getWelcomeEmailTemplate } from "~/lib/emails/templates/welcome";
 import { completeOnboarding } from "~/lib/server/onboarding/complete-onboarding";
 
 const Body = z.object({
@@ -17,7 +19,7 @@ const SUPPORTED_HTTP_METHODS: HttpMethod[] = ["POST"];
 async function onboardingHandler(req: NextApiRequest, res: NextApiResponse) {
   const body = await Body.parseAsync(req.body);
   const userId = req.firebaseUser.uid;
-  // const userEmail = req.firebaseUser.email;
+  const userEmail = req.firebaseUser.email;
 
   const data = {
     userId,
@@ -26,19 +28,13 @@ async function onboardingHandler(req: NextApiRequest, res: NextApiResponse) {
 
   await completeOnboarding(data);
 
-  // if (userEmail) {
-  //   const registrationEmail = getEventEmailText(
-  //     FEATURES_IDS_LIST.emailTexts.notification_of_successful_registration,
-  //   );
-
-  //   sendEmail({
-  //     to: userEmail,
-  //     subject: registrationEmail.subject,
-  //     text: registrationEmail.text,
-  //   });
-  // } else {
-  //   console.error("User email is not defined in registration request");
-  // }
+  //* Send welcome email to user
+  if (userEmail) {
+    const emailTemplate = getWelcomeEmailTemplate();
+    sendEmailWithApi(userEmail, emailTemplate);
+  } else {
+    console.error("User email is not defined in registration request");
+  }
 
   return res.send({ success: true });
 }


### PR DESCRIPTION
## Выполнено
- Поправил названия имейл темплейтов
- Добавил ивент о предстоящем списании от **Stripe**
- Раскидывал отправку имейлов на ивенты
  - При регистрации
  - При покупке подписки
  - Оповещение о скором списании (за 3 дня до)
  - Уведомление о неудачном списании
  - Уведомление об успешном продлении подписки

### Вот скрин как мне пришли пару этих имейлов
![image](https://github.com/AudioLand/dub-nextjs/assets/46379146/abc02945-51d6-4271-846f-c47006657f5d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an upcoming invoice notification for Stripe integration.
  - Added a new email template for subscription expiration notifications.
  - Implemented welcome email functionality for new user onboarding.
  - Enhanced Stripe webhook handling to send emails for subscription events.

- **Refactor**
  - Renamed email template functions for clarity and consistency.

- **Chores**
  - Removed outdated commented code from the email sending API.

- **Documentation**
  - No explicit changes, but the renaming of functions may require updates to related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->