### PR TITLE
fix: load stripe products and prices ids from env

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -106,18 +106,18 @@ const configuration = {
           {
             name: "Monthly",
             price: "$0",
-            stripePriceId: "price_1O5dATLMDoxZURVetlMftktp",
+            stripePriceId: "",
           },
           {
             name: "Yearly",
             price: "$0",
-            stripePriceId: "price_1O5dATLMDoxZURVeJ8pbEq5t",
+            stripePriceId: "",
           },
         ],
       },
       //* Creator
       {
-        stripeProductId: "prod_OuKnitbowAz4n4",
+        stripeProductId: process.env.NEXT_PUBLIC_CREATOR_PRODUCT_ID,
         name: "Creator",
         description: "10 tokens/month",
         tokens: 10,
@@ -138,18 +138,18 @@ const configuration = {
           {
             name: "Monthly",
             price: "$20",
-            stripePriceId: "price_1O6W81LMDoxZURVe5SPXElmm",
+            stripePriceId: process.env.NEXT_PUBLIC_CREATOR_MONTH_SUBSCRIPTION_ID,
           },
           {
             name: "Yearly",
             price: "$189",
-            stripePriceId: "price_1O6W81LMDoxZURVevB2MwM3Z",
+            stripePriceId: process.env.NEXT_PUBLIC_CREATOR_YEAR_SUBSCRIPTION_ID,
           },
         ],
       },
-      //* Standart
+      //* Standard
       {
-        stripeProductId: "prod_OuKpA5o0s5ysTU",
+        stripeProductId: process.env.NEXT_PUBLIC_STANDARD_PRODUCT_ID,
         name: "Standard",
         description: "30 tokens/month",
         tokens: 30,
@@ -170,18 +170,18 @@ const configuration = {
           {
             name: "Monthly",
             price: "$49",
-            stripePriceId: "price_1O6WA2LMDoxZURVe3FYhuzEy",
+            stripePriceId: process.env.NEXT_PUBLIC_STANDARD_MONTH_SUBSCRIPTION_ID,
           },
           {
             name: "Yearly",
             price: "$470",
-            stripePriceId: "price_1O6WA2LMDoxZURVe2ZmelB28",
+            stripePriceId: process.env.NEXT_PUBLIC_STANDARD_YEAR_SUBSCRIPTION_ID,
           },
         ],
       },
       //* Producer
       {
-        stripeProductId: "prod_OuKubCASJyJPoR",
+        stripeProductId: process.env.NEXT_PUBLIC_PRODUCER_PRODUCT_ID,
         name: "Producer",
         badge: `Most Popular`,
         recommended: true,
@@ -204,12 +204,12 @@ const configuration = {
           {
             name: "Monthly",
             price: "$349",
-            stripePriceId: "price_1O81jhLMDoxZURVeNz22ANJ3",
+            stripePriceId: process.env.NEXT_PUBLIC_PRODUCER_MONTH_SUBSCRIPTION_ID,
           },
           {
             name: "Yearly",
             price: "$3,349",
-            stripePriceId: "price_1O6WF3LMDoxZURVecqdybl5W",
+            stripePriceId: process.env.NEXT_PUBLIC_PRODUCER_YEAR_SUBSCRIPTION_ID,
           },
         ],
       },
@@ -242,7 +242,6 @@ const configuration = {
       },
     ],
   },
-
   feedback: [
     {
       avatarUrl: "/assets/images/google.png",


### PR DESCRIPTION
## Выполнено
- Перенёс айдишники продуктов страйпа (`Creator`, `Standard`, `Producer`) в енв
- Перенёс айдишники месячных и годовых цен каждого продукта в енв
- Добавил айдишники продуктов и их цен в версель


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Subscription plan identification now utilizes environment variables for enhanced security and flexibility.
  - User role identification has been updated to use environment variables for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->