### PR TITLE
Rask pipeline ff

### DIFF
--- a/src/components/projects/CreateProjectForm.tsx
+++ b/src/components/projects/CreateProjectForm.tsx
@@ -189,7 +189,7 @@ const CreateProjectForm: FC<CreateProjectFormProps> = (props) => {
         user_email: userEmail,
       });
 
-      const pipelineUrl = shouldUseRaskAPI ? OUR_PIPELINE_URL : RASK_PIPELINE_URL;
+      const pipelineUrl = shouldUseRaskAPI ? RASK_PIPELINE_URL : OUR_PIPELINE_URL;
 
       const url = `${pipelineUrl}/?${requestParams.toString()}`;
       const response = await fetch(url);

--- a/src/components/projects/CreateProjectForm.tsx
+++ b/src/components/projects/CreateProjectForm.tsx
@@ -19,14 +19,16 @@ import TextField from "~/core/ui/TextField";
 import FileUploader from "./FileUploader";
 
 // hooks
+import { useUserSession } from "~/core/hooks/use-user-session";
 import useCreateProject from "~/lib/projects/hooks/use-create-project";
-import useVideoFileDuration from "~/lib/projects/hooks/use-video-file-duration";
 import useTargetLanguages from "~/lib/projects/hooks/use-target-languages";
 import useUpdateProject from "~/lib/projects/hooks/use-update-project";
 import useUploadFileToStorage from "~/lib/projects/hooks/use-upload-file-to-storage";
+import useVideoFileDuration from "~/lib/projects/hooks/use-video-file-duration";
+import { estimateProjectDuration } from "~/lib/projects/video";
 
 // constants
-import PIPELINE_URL from "~/core/ml-pipeline/url";
+import { OUR_PIPELINE_URL, RASK_PIPELINE_URL } from "~/core/ml-pipeline/url";
 import { PREVIEW_HOST_URL } from "~/lib/projects/languages-and-voices-config";
 import { filterVoicesByLanguage } from "~/lib/projects/voices";
 
@@ -37,17 +39,16 @@ import { Project } from "~/lib/projects/types/project";
 
 // icons
 import { PlayIcon } from "@heroicons/react/24/outline";
-import { useUserSession } from "~/core/hooks/use-user-session";
-import { estimateProjectDuration } from "~/lib/projects/video";
 
 interface CreateProjectFormProps {
   handleClose: () => void;
   userId: string;
   organizationId: string;
+  shouldUseRaskAPI: boolean;
 }
 
 const CreateProjectForm: FC<CreateProjectFormProps> = (props) => {
-  const { handleClose, userId, organizationId } = props;
+  const { handleClose, userId, organizationId, shouldUseRaskAPI } = props;
 
   const audioRef = useRef<HTMLAudioElement>(null);
 
@@ -188,7 +189,9 @@ const CreateProjectForm: FC<CreateProjectFormProps> = (props) => {
         user_email: userEmail,
       });
 
-      const url = `${PIPELINE_URL}/?${requestParams.toString()}`;
+      const pipelineUrl = shouldUseRaskAPI ? OUR_PIPELINE_URL : RASK_PIPELINE_URL;
+
+      const url = `${pipelineUrl}/?${requestParams.toString()}`;
       const response = await fetch(url);
       if (!response.ok) {
         throw new Error("Network response was not ok");

--- a/src/components/projects/ProjectsWrapper.tsx
+++ b/src/components/projects/ProjectsWrapper.tsx
@@ -17,6 +17,7 @@ import { useCurrentOrganization } from "~/lib/organizations/hooks/use-current-or
 import useIsUserCanCreateDubs from "~/lib/projects/hooks/use-is-user-can-create-dubs";
 import useMaxMediaFileDuration from "~/lib/projects/hooks/use-max-media-file-duration";
 import useRequirementsInfoTooltipText from "~/lib/projects/hooks/use-requirements-info-tooltip-text";
+import useShouldUseRaskAPI from "~/lib/projects/hooks/use-should-use-rask-api";
 
 // constants
 import { MAX_FILE_DURATION_STRING_TEMPLATE } from "~/lib/projects/limits";
@@ -28,6 +29,8 @@ const ProjectsWrapper = () => {
   const userId = useUserId();
   const userOrganization = useCurrentOrganization();
   const [isCreateProjectModalOpen, setCreateProjectModalOpen] = useState<boolean>(false);
+
+  const shouldUseRaskAPI = useShouldUseRaskAPI();
 
   const handleOpenCreateProjectModal = () => {
     setCreateProjectModalOpen(true);
@@ -64,6 +67,7 @@ const ProjectsWrapper = () => {
           userId={userId}
           organizationId={userOrganization.id}
           handleClose={handleCloseCreateProjectModal}
+          shouldUseRaskAPI={shouldUseRaskAPI}
         />
       </Modal>
     </>

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -283,7 +283,6 @@ const configuration = {
         "“I used Audioland for dubbing my web series, and the outcome was fantastic. The voices matched our characters' personalities perfectly even they were cloned with AI, and the emotional delivery was spot on. The process was smooth, although pricing was a bit higher than expected. However, the quality justifies the cost. Highly recommended for anyone looking to dub entertainment content...“",
     } as FeedbackCardType,
   ],
-
   magic: {
     // https://www.notion.so/krenels/61d2dd45bea5420baf770e621b40ad2e?pvs=4
     projectDurationMultiplicator: 2,

--- a/src/core/flagsmith/features-ids-list.ts
+++ b/src/core/flagsmith/features-ids-list.ts
@@ -1,6 +1,7 @@
 const FEATURES_IDS_LIST = {
   languages_list: "languages_list",
   requirements_info_tooltip: "requirements_info_tooltip",
+  use_rask_api: "use_rask_api",
 
   emailTexts: {
     notification_of_a_failed_payment_attempt: "notification_of_a_failed_payment_attempt",

--- a/src/core/ml-pipeline/url.ts
+++ b/src/core/ml-pipeline/url.ts
@@ -1,7 +1,2 @@
-const PIPELINE_PRODUCTION_URL = "https://audioland.fly.dev";
-const PIPELINE_DEVELOPMENT_URL = "http://localhost:8080";
-
-const PIPELINE_URL =
-  process.env.NODE_ENV == "development" ? PIPELINE_DEVELOPMENT_URL : PIPELINE_PRODUCTION_URL;
-
-export default PIPELINE_URL;
+export const OUR_PIPELINE_URL = "https://audioland.fly.dev";
+export const RASK_PIPELINE_URL = "https://audioland-rask.fly.dev";

--- a/src/lib/projects/hooks/use-should-use-rask-api.ts
+++ b/src/lib/projects/hooks/use-should-use-rask-api.ts
@@ -1,0 +1,12 @@
+// flagsmith
+import flagsmith from "flagsmith";
+
+// constants
+import FEATURES_IDS_LIST from "~/core/flagsmith/features-ids-list";
+
+const useShouldUseRaskAPI = () => {
+  const shouldUseRaskAPI: boolean = flagsmith.hasFeature(FEATURES_IDS_LIST.use_rask_api);
+  return shouldUseRaskAPI;
+};
+
+export default useShouldUseRaskAPI;


### PR DESCRIPTION
## Выполнено
- Убрал ссылку на локальный пайплайн в тестах, раз мы всё равно не можем всё целиком локально запускать
- Добавил хук для получения "использовать rask api или нет"
- Теперь можно, переключая флаг, менять то, какой пайплайн будет использоваться для проектов

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to switch between different project creation pipelines based on user settings.
  - Added feature flagging to dynamically select the appropriate API for project creation.

- **Refactor**
  - Streamlined the logic for determining the project creation pipeline URL.
  - Implemented custom hooks for better state management regarding API selection.

- **Configuration**
  - Updated the configuration object and feature IDs list to support new feature flagging capabilities.

- **Documentation**
  - No visible changes to end-user documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->