### PR TITLE
User tokens updating

### DIFF
--- a/functions/src/requests/updateUserTokens.ts
+++ b/functions/src/requests/updateUserTokens.ts
@@ -26,7 +26,6 @@ export const updateUserTokens = onRequest(async (request, response) => {
       if (organizationData) {
         const organizationPrevTokens = Number(organizationData.usedTokensInSeconds) || 0;
         const newUsedTokensCount = organizationPrevTokens + tokens;
-        console.log(organizationPrevTokens);
         organizationRef.update({
           usedTokensInSeconds: newUsedTokensCount,
         });

--- a/src/core/stripe/stripe-webhooks.enum.ts
+++ b/src/core/stripe/stripe-webhooks.enum.ts
@@ -8,5 +8,6 @@ export enum StripeWebhooks {
   SubscriptionUpdated = "customer.subscription.updated",
   InvoicePaid = "invoice.paid",
   InvoicePaymentFailed = "invoice.payment_failed",
+  InvoicePaymentSucceeded = "invoice.payment_succeeded",
   InvoiceUpcoming = "invoice.upcoming",
 }

--- a/src/lib/server/organizations/subscriptions.ts
+++ b/src/lib/server/organizations/subscriptions.ts
@@ -53,7 +53,7 @@ export async function updateSubscriptionById(
 
   return organization.update({
     subscription,
-    usedTokensInSeconds: 0,
+    // usedTokensInSeconds: 0,
   });
 }
 

--- a/src/pages/api/stripe/webhook.ts
+++ b/src/pages/api/stripe/webhook.ts
@@ -106,8 +106,6 @@ async function checkoutWebhooksHandler(req: NextApiRequest, res: NextApiResponse
 
         const invoice = event.data.object as Stripe.Invoice;
         const userEmail = invoice.customer_email;
-        console.log(event);
-        console.log(userEmail);
 
         await onSubscriptionUpdated(subscription);
 
@@ -120,6 +118,27 @@ async function checkoutWebhooksHandler(req: NextApiRequest, res: NextApiResponse
         } else {
           console.error("User email is not defined in Stripe paid invoice event");
         }
+
+        break;
+      }
+
+      case StripeWebhooks.InvoicePaymentSucceeded: {
+        // const subscription = event.data.object as Stripe.Subscription;
+
+        const invoice = event.data.object as Stripe.Invoice;
+        // const userEmail = invoice.customer_email;
+
+        await resetTokensByCustomerId(invoice.customer as string);
+
+        // //* Send email that subscription renew payment is successful
+        // if (userEmail) {
+        //   const organizationSubscription = buildOrganizationSubscription(subscription);
+        //   sendEmailWithApi(userEmail, EmailTemplate.SubscriptionAutoRenew, {
+        //     subscription: organizationSubscription,
+        //   });
+        // } else {
+        //   console.error("User email is not defined in Stripe paid invoice event");
+        // }
 
         break;
       }


### PR DESCRIPTION
## Выполнено
- Добавил новый **Stripe** ивент `invoice.payment_succeeded`, который в теории срабатывает только когда подписка автоматически продливается
- Удалил лишние `console.log`'и

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed unnecessary logging of sensitive data during token updates and Stripe webhook handling.
- **New Features**
	- Integrated handling for Stripe `InvoicePaymentSucceeded` webhook to support subscription renewals.
- **Refactor**
	- Updated subscription update logic to maintain `usedTokensInSeconds` correctly during renewal processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->