### PR TITLE
feat: show available languages in target language select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "swr": "^2.2.4",
         "tailwind-merge": "^1.14.0",
         "tailwindcss-animate": "^1.0.7",
+        "title-case": "^4.3.1",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -24514,6 +24515,11 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
       "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
       "optional": true
+    },
+    "node_modules/title-case": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-4.3.1.tgz",
+      "integrity": "sha512-VnPxQ+/j0X2FZ4ceGq1oLruTLjtN5Ul4sam5ypd4mDZLm1eHwkwip1gLxqhON/j4qyTlUlfPKslE/t4NPSlxhg=="
     },
     "node_modules/titleize": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "swr": "^2.2.4",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7",
+    "title-case": "^4.3.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/components/projects/CreateProjectForm.tsx
+++ b/src/components/projects/CreateProjectForm.tsx
@@ -88,8 +88,9 @@ const CreateProjectForm: FC<CreateProjectFormProps> = (props) => {
   const [languageErrorMessage, setLanguageErrorMessage] = useState<string>("");
   const [fileErrorMessage, setFileErrorMessage] = useState<string>("");
 
-  const targetLanguages = useTargetLanguages();
+  const targetLanguages = useTargetLanguages(shouldUseAlexAPI);
   const availableVoices = filterVoicesByLanguage(newProject.targetLanguage, shouldUseAlexAPI);
+
   const isLanguageSelected = availableVoices.length === 0;
 
   const handleNameUpdate = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/lib/projects/hooks/use-target-languages.ts
+++ b/src/lib/projects/hooks/use-target-languages.ts
@@ -1,20 +1,26 @@
-// flagsmith
-import flagsmith from "flagsmith";
+import { titleCase } from "title-case";
+import { AVAILABLE_LANGUAGES, LANGUAGES_AND_VOICES_CONFIG } from "../languages-and-voices-config";
 
-// constants
-import FEATURES_IDS_LIST from "~/core/flagsmith/features-ids-list";
+const getAvailableLanguagesByProvider = (provider: string) => {
+  return Array.from(
+    // Get unique languages
+    new Set(
+      LANGUAGES_AND_VOICES_CONFIG.filter((voice) => voice.provider === provider).flatMap(
+        (voice) => voice.languages,
+      ),
+    ),
+  );
+}
 
-const useTargetLanguages = () => {
-  const valueString: string = flagsmith.getValue(FEATURES_IDS_LIST.languages_list);
-  let targetLanguages: string[];
-  try {
-    targetLanguages = JSON.parse(valueString);
-  } catch (error) {
-    console.error("Failed to parse json of target languages:", error);
-    targetLanguages = [];
+const useTargetLanguages = (shouldUseAlexAPI: boolean) => {
+  // Get langs only with 11labs provider
+  if (shouldUseAlexAPI) {
+    const availableLanguages = getAvailableLanguagesByProvider('eleven_labs')
+    return availableLanguages.map(lang => titleCase(lang));
   }
 
-  return targetLanguages;
+  // Get all available languages in TTS config
+  return AVAILABLE_LANGUAGES;
 };
 
 export default useTargetLanguages;

--- a/src/lib/projects/languages-and-voices-config.ts
+++ b/src/lib/projects/languages-and-voices-config.ts
@@ -1,3 +1,5 @@
+import { titleCase } from "title-case";
+
 export const PREVIEW_HOST_URL = "https://speechki-book.s3.amazonaws.com";
 
 export const LANGUAGES_AND_VOICES_CONFIG = [
@@ -7482,3 +7484,12 @@ export const LANGUAGES_AND_VOICES_CONFIG = [
     languages: ["tamil"],
   },
 ];
+
+export const AVAILABLE_LANGUAGES = Array.from(
+  // Get unique languages
+  new Set(
+    LANGUAGES_AND_VOICES_CONFIG.flatMap(
+      (voice) => voice.languages,
+    ),
+  ),
+).map(lang => titleCase(lang));


### PR DESCRIPTION
- сделал фильтрацию языков в селекте target language, чтобы показывались только те языки которые поддерживаются провайдером

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Create Project form to support dynamic language selection based on a new provider option.
- **Refactor**
	- Updated language selection logic to conditionally fetch and process available languages, including title casing based on provider selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->